### PR TITLE
Comentários sobre obsolescência

### DIFF
--- a/obsolescence_comments.md
+++ b/obsolescence_comments.md
@@ -1,0 +1,17 @@
+**main.py (Linha 1):** Obsolescência detectada. Razão: O módulo 'distutils.core' está obsoleto em Python 3.12. Use 'setuptools' em seu lugar.. Sugestão: from setuptools import setup.
+
+**main.py (Linha 7):** Obsolescência detectada. Razão: A estrutura de pacotes no 'distutils' foi alterada. A opção 'packages' agora requer a especificação do diretório do pacote.. Sugestão: packages=['meu_modulo'],
+    package_dir={'': 'meu_modulo'},.
+
+**teste.py (Linha 1):** Obsolescência detectada. Razão: O módulo 'distutils.core' está obsoleto em Python 3.12. O módulo 'setuptools' é recomendado para criar pacotes Python.. Sugestão: from setuptools import setup.
+
+**teste.py (Linha 4):** Obsolescência detectada. Razão: É recomendado adicionar a restrição de versão para Python 3.6 ou superior, pois o módulo 'distutils' foi depreciado no Python 3.10 e removido no Python 3.12.. Sugestão:     setup(
+        name='meu_pacote',
+        version='0.1dev',
+        packages=['meu_modulo'],
+        description='Um exemplo de pacote usando distutils',
+        author='Seu Nome',
+        author_email='seu.email@example.com',
+        url='http://exemplo.com',
+        python_requires='>=3.6',  # Adiciona a restrição de versão para Python 3.6 ou superior
+    ).


### PR DESCRIPTION
Este PR contém comentários sobre obsolescências identificadas:

**main.py (Linha 1):** Obsolescência detectada. Razão: O módulo 'distutils.core' está obsoleto em Python 3.12. Use 'setuptools' em seu lugar.. Sugestão: from setuptools import setup.
**main.py (Linha 7):** Obsolescência detectada. Razão: A estrutura de pacotes no 'distutils' foi alterada. A opção 'packages' agora requer a especificação do diretório do pacote.. Sugestão: packages=['meu_modulo'],
    package_dir={'': 'meu_modulo'},.
**teste.py (Linha 1):** Obsolescência detectada. Razão: O módulo 'distutils.core' está obsoleto em Python 3.12. O módulo 'setuptools' é recomendado para criar pacotes Python.. Sugestão: from setuptools import setup.
**teste.py (Linha 4):** Obsolescência detectada. Razão: É recomendado adicionar a restrição de versão para Python 3.6 ou superior, pois o módulo 'distutils' foi depreciado no Python 3.10 e removido no Python 3.12.. Sugestão:     setup(
        name='meu_pacote',
        version='0.1dev',
        packages=['meu_modulo'],
        description='Um exemplo de pacote usando distutils',
        author='Seu Nome',
        author_email='seu.email@example.com',
        url='http://exemplo.com',
        python_requires='>=3.6',  # Adiciona a restrição de versão para Python 3.6 ou superior
    ).