### PR TITLE
Comentários sobre obsolescência

### DIFF
--- a/obsolescence_comments.md
+++ b/obsolescence_comments.md
@@ -1,0 +1,14 @@
+# Comentários sobre Obsolescências
+
+### teste.py (Linha 1)
+- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto em Python 3.12. Utilize 'setuptools' para criar pacotes Python.
+- **Codigo atual:** from distutils.core import setup
+- **Sugestão:** from setuptools import setup
+
+
+### teste.py (Linha 7)
+- **Obsolescência detectada:** A instalação de pacotes deve ser declarada explicitamente utilizando 'install_requires' no setup.
+- **Codigo atual:** packages=['meu_modulo'],
+- **Sugestão:** packages=['meu_modulo'],
+    install_requires=['meu_pacote'],
+


### PR DESCRIPTION
Este PR contém comentários sobre obsolescências identificadas:

### teste.py (Linha 1)
- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto em Python 3.12. Utilize 'setuptools' para criar pacotes Python.
- **Codigo atual:** from distutils.core import setup
- **Sugestão:** from setuptools import setup


### teste.py (Linha 7)
- **Obsolescência detectada:** A instalação de pacotes deve ser declarada explicitamente utilizando 'install_requires' no setup.
- **Codigo atual:** packages=['meu_modulo'],
- **Sugestão:** packages=['meu_modulo'],
    install_requires=['meu_pacote'],

