### PR TITLE
Comentários sobre obsolescência

### DIFF
--- a/obsolescence_comments.md
+++ b/obsolescence_comments.md
@@ -1,0 +1,25 @@
+# Comentários sobre Obsolescências
+
+### main.py (Linha 1)
+- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto e foi substituído por 'setuptools'. Use 'setuptools' para criar e gerenciar pacotes Python.
+- **Código atual:** from distutils.core import setup
+- **Sugestão:** from setuptools import setup
+
+
+### main.py (Linha 11)
+- **Obsolescência detectada:** O módulo 'distutils' está obsoleto e foi substituído por 'setuptools'. Use 'setuptools' para criar e gerenciar pacotes Python.
+- **Código atual:** description='Um exemplo de pacote usando distutils'
+- **Sugestão:** description='Um exemplo de pacote usando setuptools'
+
+
+### teste.py (Linha 1)
+- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto em Python 3.12 e deve ser substituído por 'setuptools'.
+- **Código atual:** from distutils.core import setup
+- **Sugestão:** from setuptools import setup
+
+
+### teste.py (Linha 14)
+- **Obsolescência detectada:** A função 'print' não é mais considerada obsoleta, mas deve ser usada com a sintaxe de string f para melhor legibilidade.
+- **Código atual:** print("Pacote configurado com sucesso!")
+- **Sugestão:** print("Pacote configurado com sucesso!")
+


### PR DESCRIPTION
Este PR contém comentários sobre obsolescências identificadas:

### main.py (Linha 1)
- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto e foi substituído por 'setuptools'. Use 'setuptools' para criar e gerenciar pacotes Python.
- **Código atual:** from distutils.core import setup
- **Sugestão:** from setuptools import setup


### main.py (Linha 11)
- **Obsolescência detectada:** O módulo 'distutils' está obsoleto e foi substituído por 'setuptools'. Use 'setuptools' para criar e gerenciar pacotes Python.
- **Código atual:** description='Um exemplo de pacote usando distutils'
- **Sugestão:** description='Um exemplo de pacote usando setuptools'


### teste.py (Linha 1)
- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto em Python 3.12 e deve ser substituído por 'setuptools'.
- **Código atual:** from distutils.core import setup
- **Sugestão:** from setuptools import setup


### teste.py (Linha 14)
- **Obsolescência detectada:** A função 'print' não é mais considerada obsoleta, mas deve ser usada com a sintaxe de string f para melhor legibilidade.
- **Código atual:** print("Pacote configurado com sucesso!")
- **Sugestão:** print("Pacote configurado com sucesso!")

