### PR TITLE
Comentários sobre obsolescência

### DIFF
--- a/obsolescence_comments.md
+++ b/obsolescence_comments.md
@@ -1,0 +1,13 @@
+# Comentários sobre Obsolescências
+
+### teste.py (Linha 1)
+- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto. Utilize 'setuptools' em vez de 'distutils' para gerenciamento de pacotes em Python.
+- **Código atual:** from distutils.core import setup
+- **Sugestão:** from setuptools import setup
+
+
+### teste.py (Linha 9)
+- **Obsolescência detectada:** O atributo 'packages' em 'setup' não inclui automaticamente as dependências do pacote. Utilize o atributo 'install_requires' para declarar as dependências do pacote.
+- **Código atual:** packages=['meu_modulo']
+- **Sugestão:** packages=['meu_modulo'],  install_requires=['meu_modulo']
+


### PR DESCRIPTION
Este PR contém comentários sobre obsolescências identificadas:

### teste.py (Linha 1)
- **Obsolescência detectada:** O módulo 'distutils.core' está obsoleto. Utilize 'setuptools' em vez de 'distutils' para gerenciamento de pacotes em Python.
- **Código atual:** from distutils.core import setup
- **Sugestão:** from setuptools import setup


### teste.py (Linha 9)
- **Obsolescência detectada:** O atributo 'packages' em 'setup' não inclui automaticamente as dependências do pacote. Utilize o atributo 'install_requires' para declarar as dependências do pacote.
- **Código atual:** packages=['meu_modulo']
- **Sugestão:** packages=['meu_modulo'],  install_requires=['meu_modulo']

